### PR TITLE
Update APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md

### DIFF
--- a/Instructions/Labs/APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md
+++ b/Instructions/Labs/APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md
@@ -155,7 +155,7 @@ In this exercise, you will use a managed identity to configure a new service con
 
 1. Select the **New service connection** button and select **Azure Resource Manager**.
 
-1. Select **Managed Identity** as the **Authentication method**.
+1. Select **Managed Identity (agent-assigned)** as the **Authentication method**.
 
 1. Set the scope level to **Subscription** and provide the information from the Azure portal, including the **Subscription Id**, **Subscription name**, and **Tenant Id**.
 


### PR DESCRIPTION
Fixing type of Managed Identity to match AzDo current label

> **Note**
> M03_L03: Managed Identity should specify "agent-assigned"

## Related Issue

**Link related Github Issue** 🢂 Fixes #57 .

## Checklist

Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:

- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/ProjectSpike/blob/main/.github/CONTRIBUTING.md) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/ProjectSpike/blob/main/.github/CONTRIBUTING.md) 

Changes proposed in this pull request:

- Updating Service Connection menu name in the tutorial to align with exercice's intent
