### PR TITLE
Modify build task to use arguments for configuration

### DIFF
--- a/Instructions/Labs/APL2001_M07_L07_Configure_Pipelines_to_Securely_Use_Variables_and_Parameters.md
+++ b/Instructions/Labs/APL2001_M07_L07_Configure_Pipelines_to_Securely_Use_Variables_and_Parameters.md
@@ -145,12 +145,12 @@ In this task, you will secure the variables and parameters from your pipeline by
      - group: BuildConfigurations
    ```
 
-1. In the "Build" task, add the configuration parameter to the task to utilize the build configuration from the variable group.
+1. In the "Build" task, add the arguments input with the configuration parameter to the task to utilize the build configuration from the variable group.
 
     ```yaml
             command: 'build'
             projects: ${{ parameters.dotNetProjects }}
-            configuration: $(buildConfiguration)
+            arguments: '--configuration $(buildConfiguration)'
     ```
 
 1. Click on **Validate and save** to save the changes, then click on **Save**.


### PR DESCRIPTION
## Related Issue

**Link related Github Issue** 🢂 Fixes #62 
## Checklist

Mark completed with "x" between brackets, "[x]", or checking the box once the PR is created:

- [x] Has related GitHub Issue 💥 [Create Issue](https://github.com/MicrosoftLearning/ProjectSpike/blob/main/.github/CONTRIBUTING.md) 📝
- [x] Tested it
- [x] Read the PR collaboration guide 👓 [Collaboration Guide](https://github.com/MicrosoftLearning/ProjectSpike/blob/main/.github/CONTRIBUTING.md) 

Changes proposed in this pull request:

- Updated instructions to use 'arguments' input for build configuration.