### PR TITLE
Backfill missing lab metadata (8 files)

### DIFF
--- a/Instructions/Labs/APL2001_M00_Validate_Lab_Environment.md
+++ b/Instructions/Labs/APL2001_M00_Validate_Lab_Environment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Validate your lab environment'
-    module: 'Module 0: Welcome'
+  title: Validate your lab environment
+  module: 'Module 0: Welcome'
+  description: In preparation for the labs, it is crucial to have your environment
+    correctly set up. This page will guide you through the setup process, ensuring
+    all prerequisites are met.
+  duration: 92 minutes
+  level: 400
+  islab: true
 ---
 
 # Validate your lab environment

--- a/Instructions/Labs/APL2001_M01_L01_Configure_a_Project_and_Repository_Structure_to_Support_Secure_Pipelines.md
+++ b/Instructions/Labs/APL2001_M01_L01_Configure_a_Project_and_Repository_Structure_to_Support_Secure_Pipelines.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Configure a project and repository structure to support secure pipelines'
-    module: 'Module 1: Configure a project and repository structure to support secure pipelines'
+  title: Configure a project and repository structure to support secure pipelines
+  module: 'Module 1: Configure a project and repository structure to support secure
+    pipelines'
+  description: In this lab, you will learn how to configure a project and repository
+    structure in Azure DevOps to support secure pipelines. This lab covers best practices
+    for organizing projects and repositories, assigning permissions, and managing
+    secure files.
+  duration: 144 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
 ---
 
 # Configure a project and repository structure to support secure pipelines

--- a/Instructions/Labs/APL2001_M02_L02_Configure_Agents_And_Agent_Pools_for_Secure_Pipelines.md
+++ b/Instructions/Labs/APL2001_M02_L02_Configure_Agents_And_Agent_Pools_for_Secure_Pipelines.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: Configure agents and agent pools for secure pipelines
-    module: 'Module 2: Configure secure access to pipeline resources'
+  title: Configure agents and agent pools for secure pipelines
+  module: 'Module 2: Configure secure access to pipeline resources'
+  description: In this lab, you will learn how to configure Azure DevOps agents and
+    agent Pools and manage permissions for those pools. Azure DevOps Agent Pools provide
+    the resources to run your build and release pipelines.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
 ---
 
 # Configure agents and agent pools for secure pipelines

--- a/Instructions/Labs/APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md
+++ b/Instructions/Labs/APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md
@@ -1,7 +1,19 @@
 ---
 lab:
-    title: 'Managed identity for projects and pipelines'
-    module: 'Module 3: Manage identity for projects, pipelines, and agents'
+  title: Managed identity for projects and pipelines
+  module: 'Module 3: Manage identity for projects, pipelines, and agents'
+  description: Managed identities offer a secure method for controlling access to
+    Azure resources. Azure handles these identities automatically, allowing you to
+    verify access to services compatible with Azure AD authentication. This means
+    you won't need to embed credentials into your code, enhancing security. In Azure
+    DevOps, managed identities can authenticate Azure resources within your self-hosted
+    agents, simplifying access control without compromising security.
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
 ---
 
 # Managed identity for projects and pipelines

--- a/Instructions/Labs/APL2001_M04_L04_Configure_and_Validate_Permissions.md
+++ b/Instructions/Labs/APL2001_M04_L04_Configure_and_Validate_Permissions.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Configure and validate permissions'
-    module: 'Module 4: Configure and validate permissions'
+  title: Configure and validate permissions
+  module: 'Module 4: Configure and validate permissions'
+  description: In this lab, you'll set up a secure environment that adheres to the
+    principle of least privilege, ensuring that members can access only the resources
+    they need to perform their tasks and minimize potential security risks. This involves
+    configuring and validating user and pipeline permissions and setting up approval
+    and branch checks in Azure DevOps.
+  duration: 120 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
 ---
 
 # Configure and validate permissions

--- a/Instructions/Labs/APL2001_M05_L05_Extend_a_Pipeline_to_Use_Multiple_Templates.md
+++ b/Instructions/Labs/APL2001_M05_L05_Extend_a_Pipeline_to_Use_Multiple_Templates.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Extend a pipeline to use multiple templates'
-    module: 'Module 5: Extend a pipeline to use multiple templates'
+  title: Extend a pipeline to use multiple templates
+  module: 'Module 5: Extend a pipeline to use multiple templates'
+  description: In this lab, explore the importance of extending a pipeline to multiple
+    templates and how to do it using Azure DevOps. This lab covers fundamental concepts
+    and best practices for creating a multi-stage pipeline, creating a variables template,
+    creating a job template, and creating a stage template.
+  duration: 100 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
 ---
 
 # Extend a pipeline to use multiple templates

--- a/Instructions/Labs/APL2001_M06_L06_Integrate_Azure_Key_Vault_With_Azure_Pipelines.md
+++ b/Instructions/Labs/APL2001_M06_L06_Integrate_Azure_Key_Vault_With_Azure_Pipelines.md
@@ -1,7 +1,21 @@
 ---
 lab:
-    title: 'Integrate Azure Key Vault with Azure Pipelines'
-    module: 'Module 6: Configure secure access to Azure Repos from pipelines'
+  title: Integrate Azure Key Vault with Azure Pipelines
+  module: 'Module 6: Configure secure access to Azure Repos from pipelines'
+  description: Azure Key Vault provides secure storage and management of sensitive
+    data, such as keys, passwords, and certificates. Azure Key Vault includes support
+    for hardware security modules and a range of encryption algorithms and key lengths.
+    By using Azure Key Vault, you can minimize the possibility of disclosing sensitive
+    data through source code, a common mistake developers make. Access to Azure Key
+    Vault requires proper authentication and authorization, supporting fine-grained
+    permissions to its content.
+  duration: 5 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Key Vault
+  - Azure Pipelines
 ---
 
 # Integrate Azure Key Vault with Azure Pipelines

--- a/Instructions/Labs/APL2001_M07_L07_Configure_Pipelines_to_Securely_Use_Variables_and_Parameters.md
+++ b/Instructions/Labs/APL2001_M07_L07_Configure_Pipelines_to_Securely_Use_Variables_and_Parameters.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Configure pipelines to securely use variables and parameters'
-    module: 'Module 7: Configure pipelines to securely use variables and parameters'
+  title: Configure pipelines to securely use variables and parameters
+  module: 'Module 7: Configure pipelines to securely use variables and parameters'
+  description: In this lab, you will learn how to configure pipelines to securely
+    use variables and parameters.
+  duration: 100 minutes
+  level: 200
+  islab: true
 ---
 
 # Configure pipelines to securely use variables and parameters


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 8

- `Instructions/Labs/APL2001_M00_Validate_Lab_Environment.md` (description,duration,level,islab)
- `Instructions/Labs/APL2001_M01_L01_Configure_a_Project_and_Repository_Structure_to_Support_Secure_Pipelines.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M02_L02_Configure_Agents_And_Agent_Pools_for_Secure_Pipelines.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M03_L03_Managed_Identity_for_Projects_and_Pipelines.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M04_L04_Configure_and_Validate_Permissions.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M05_L05_Extend_a_Pipeline_to_Use_Multiple_Templates.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M06_L06_Integrate_Azure_Key_Vault_With_Azure_Pipelines.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/APL2001_M07_L07_Configure_Pipelines_to_Securely_Use_Variables_and_Parameters.md` (description,duration,level,islab)
